### PR TITLE
CORS header fixes

### DIFF
--- a/lib/pipelines/add-cors-header.js
+++ b/lib/pipelines/add-cors-header.js
@@ -9,17 +9,33 @@ class AddCorsHeader {
             if (!options.cors) {
                 return content;
             }
-            const cors = this.readTemplate(serverless)
+            const cors = this.readTemplate(serverless);
+            const addCors = responseContent => {
+                if (!responseContent.hasOwnProperty('headers')) {
+                    let headers = {headers: cors};
+                    Object.assign(responseContent, merge(responseContent, headers));
+                } else {
+                    Object.assign(responseContent.headers, merge(responseContent.headers, cors));
+                }
+            }
+
+            // Add cors to each reusable response
+            Object.entries(content.components.responses).forEach(([name, responseContent]) => {
+                addCors(responseContent)
+            });
+
+            // Add cors to each operation
             Object.entries(content.paths).forEach(([path, pathContent]) => {
                 Object.entries(pathContent).forEach(([method, methodContent]) => {
-                    Object.entries(methodContent.responses).forEach(([response, responseContent]) => {
-                        if (!responseContent.hasOwnProperty('headers')) {
-                            let headers = {headers: cors};
-                            Object.assign(responseContent, merge(responseContent, headers));
-                        } else {
-                            Object.assign(responseContent.headers, merge(responseContent.headers, cors));
-                        }
-                    });
+                    // Ignore entries without 'responses' (such as parameters)
+                    if (methodContent.responses) {
+                        Object.entries(methodContent.responses).forEach(([response, responseContent]) => {
+                            // Ignore references (referenced responses are updated separately)
+                            if (!responseContent.hasOwnProperty('$ref')) {
+                                addCors(responseContent);
+                            }
+                        });
+                    }
                 });
             });
 
@@ -37,7 +53,7 @@ class AddCorsHeader {
                 serverless.cli.log(
                     `Process custom CORS header template`,
                     'OpenApi Integration Plugin',
-                    );
+                );
                 return jsYml.load(fs.readFileSync(templatePath))
             }
         } catch (err) {


### PR DESCRIPTION
Two problems were addressed:

1. When adding cors headers to each operation, non-method objects under each path item were mistakenly also modified. For example in a document like this:

```
    paths:
      /pets:
        parameters:
          ...
        get:
          ...

```
Here, any content under the `parameters` object should not be modified - only HTTP method object such as get, post, put etc.

2. Referenced responses were modified inline. This caused the resulting document to be invalid. Example:

```
    components:
      responses:
        MyErrorResponse:
          content:
            ...
    paths:
      /pets:
        get:
          ...
          responses:
            400:
              $ref: '#/components/responses/MyErrorResponse'
```

Here, the object under the '400' key must not be modified, since a $ref must not be combined with other attributes.
Instead, each response object found under components/responses are modified with CORS content as well.