### PR TITLE
Fix CORS responses issue

### DIFF
--- a/lib/pipelines/add-cors-response-parameters.js
+++ b/lib/pipelines/add-cors-response-parameters.js
@@ -11,9 +11,17 @@ class AddCorsResponseParameters {
             }
 
             const cors = this.readTemplate(serverless);
+
             Object.entries(content.paths).forEach(([key, pathContent]) => {
                 Object.entries(pathContent).forEach(([method, methodContent]) => {
                     if ((methodContent.hasOwnProperty('x-amazon-apigateway-integration'))) {
+                        if (!methodContent['x-amazon-apigateway-integration'].responses) {
+                            // The integration omitted a 'responses' dictionary - generate one
+                            methodContent['x-amazon-apigateway-integration'].responses =
+                                Object.keys(methodContent.responses).reduce((responses, statusCode) => {
+                                    return Object.assign(responses, {[statusCode]: {statusCode}});
+                                }, {});
+                        }
                         Object.entries(methodContent['x-amazon-apigateway-integration'].responses).forEach(([responses, responseContent]) => {
                             if (!responseContent.hasOwnProperty('responseParameters')) {
                                 let params = {responseParameters: cors};
@@ -40,7 +48,7 @@ class AddCorsResponseParameters {
                 serverless.cli.log(
                     `Process custom CORS response-parameters template`,
                     'OpenApi Integration Plugin'
-                    );
+                );
                 return jsYml.load(fs.readFileSync(templatePath))
             }
         } catch (err) {


### PR DESCRIPTION
If an integration has no responses dictionary, the CORS code to inject responseParameters would throw. Generating a responses dictionary if it's missing to fix the error.