### PR TITLE
Use contentHandling: CONVERT_TO_TEXT for CORS mock integrations

### DIFF
--- a/templates/cors/integration.yml
+++ b/templates/cors/integration.yml
@@ -1,5 +1,6 @@
 x-amazon-apigateway-integration:
   type: mock
+  contentHandling: CONVERT_TO_TEXT
   requestTemplates:
     application/json: |
       {


### PR DESCRIPTION
If an API uses contentHandling: CONVERT_TO_BINARY anywhere, the generated mock integrations for CORS would fail with a 500 error.

This turned out to be due to a missing CONVERT_TO_BINARY attribute. Ref: https://github.com/vendia/serverless-express/issues/58#issuecomment-303193847