### PR TITLE
Disable security for CORS integrations

### DIFF
--- a/templates/cors/path.yml
+++ b/templates/cors/path.yml
@@ -1,5 +1,6 @@
 summary: Provide CORS
 description: Basic CORS functionality with an aws mocking integration
+security: []
 responses:
   "204":
     description: No data


### PR DESCRIPTION
Normally, CORS preflight requests are not authenticated. This change modifies the default template for OPTIONS integrations to override the list of security schemes with an empty list.

Without this change, API gateway will sometimes apply the same security scheme as used by other methods, even if the method itself doesn't specify `security`.