### PR TITLE
Add missing null check for responses when injecting CORS headers

### DIFF
--- a/lib/pipelines/add-cors-header.js
+++ b/lib/pipelines/add-cors-header.js
@@ -19,10 +19,12 @@ class AddCorsHeader {
                 }
             }
 
-            // Add cors to each reusable response
-            Object.entries(content.components.responses).forEach(([name, responseContent]) => {
-                addCors(responseContent)
-            });
+            if (content.components.responses) {
+                // Add cors to each reusable response
+                Object.entries(content.components.responses).forEach(([name, responseContent]) => {
+                    addCors(responseContent);
+                });
+            }
 
             // Add cors to each operation
             Object.entries(content.paths).forEach(([path, pathContent]) => {


### PR DESCRIPTION
The previous PR for adding CORS headers to reusable responses under components/responses was missing a check for whether components/responses was defined at all. Since this is an optional element in an OpenAPI specification, a null check was added.